### PR TITLE
adds listing foreign key to trips to create that association. edits rake file, edits factory. I think there is something wrong with my atom. when i switch branches I don't lose any information in my files even if the branch I'm switching to doesn't have it. That is why these files have the changes I've made to the search partial that shouldn't be on this branch. May cause duplicates

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -10,6 +10,7 @@ class Listing < ApplicationRecord
   has_many :listing_images, dependent: :destroy
   has_many :listing_amenities
   has_many :amenities, through: :listing_amenities
+  has_many :trips
 
   enum property_type: [:house, :apartment, :guesthouse, :boat, :treehouse]
   enum room_type: [:entire_home, :private_room, :shared_room]

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -1,7 +1,8 @@
 class Trip < ApplicationRecord
   validates :start_date, :end_date, :num_guests, :trip_status, presence: true
-  
+
   belongs_to :user
+  belongs_to :listing
 
   enum trip_status: [:requested, :pending, :accepted, :paid]
 end

--- a/app/views/shared/_search_partial.html.erb
+++ b/app/views/shared/_search_partial.html.erb
@@ -1,0 +1,12 @@
+<div class="navbar-search">
+    <form action="/search" method="get">
+      <div class="search_bar">
+        <input name="city" placeholder="City..." type="text"></input>
+        <input name="state" placeholder="State..." type="text"></input>
+        <input name="zipcode" placeholder="Zipcode..." type="text"></input>
+        <input name="check_in" placeholder="Check In..." type="text"></input>
+        <input name="check_out" placeholder="Check Out..." type="text"></input>
+        <input type="submit" value="Search">
+      </div>
+  </form>
+</div>

--- a/db/migrate/20170714143525_add_listing_ref_to_trips.rb
+++ b/db/migrate/20170714143525_add_listing_ref_to_trips.rb
@@ -1,0 +1,5 @@
+class AddListingRefToTrips < ActiveRecord::Migration[5.1]
+  def change
+    add_reference :trips, :listing, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713171742) do
+ActiveRecord::Schema.define(version: 20170714143525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,7 +100,9 @@ ActiveRecord::Schema.define(version: 20170713171742) do
     t.integer "num_guests"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "listing_id"
     t.index ["host_id"], name: "index_trips_on_host_id"
+    t.index ["listing_id"], name: "index_trips_on_listing_id"
     t.index ["user_id"], name: "index_trips_on_user_id"
   end
 
@@ -135,6 +137,7 @@ ActiveRecord::Schema.define(version: 20170713171742) do
   add_foreign_key "listings", "addresses"
   add_foreign_key "listings", "cancellations"
   add_foreign_key "listings", "users"
+  add_foreign_key "trips", "listings"
   add_foreign_key "trips", "users"
   add_foreign_key "trips", "users", column: "host_id"
   add_foreign_key "user_roles", "roles"

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -135,11 +135,10 @@ namespace :import do
   desc "Trips"
   task trips: :environment do
     listings = Listing.all
-    listing = listings.sample
-    listing_accomodates = listing.accomodates
     users = User.all
     #hosts = User.joins(:user_roles, :roles).where(roles: {name: "host"}).uniq
     users.each do |user|
+      listing = listings.sample
       #host = hosts.sample
       trip = Trip.create!(
         listing_id: listing.id,
@@ -148,7 +147,7 @@ namespace :import do
         trip_status: ["requested", "pending", "accepted", "paid"].sample,
         start_date: Faker::Date.between(1.days.from_now, 3.days.from_now),
         end_date: Faker::Date.between(4.days.from_now, 6.days.from_now),
-        num_guests: [*1..listing_accomodates].sample
+        num_guests: [*1..listing.accomodates].sample
       )
       puts "Trip #{trip.id} created!"
     end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,7 +1,7 @@
 namespace :import do
   desc "Imports all seed data"
   task :all => [:regenerate, :roles, :users, :addresses, :cancellations, :amenities, :listings, :listing_images, :trips]
-  
+
   desc "wipes database before seeding"
   task :regenerate do
     Rails.env = "development"
@@ -134,17 +134,21 @@ namespace :import do
 
   desc "Trips"
   task trips: :environment do
+    listings = Listing.all
+    listing = listings.sample
+    listing_accomodates = listing.accomodates
     users = User.all
-    hosts = User.joins(:user_roles, :roles).where(roles: {name: "host"}).uniq
+    #hosts = User.joins(:user_roles, :roles).where(roles: {name: "host"}).uniq
     users.each do |user|
-      host = hosts.sample
+      #host = hosts.sample
       trip = Trip.create!(
+        listing_id: listing.id,
         user_id: user.id,
-        host_id: host.id,
+        host_id: listing.user_id,
         trip_status: ["requested", "pending", "accepted", "paid"].sample,
         start_date: Faker::Date.between(1.days.from_now, 3.days.from_now),
         end_date: Faker::Date.between(4.days.from_now, 6.days.from_now),
-        num_guests: [*1..4].sample
+        num_guests: [*1..listing_accomodates].sample
       )
       puts "Trip #{trip.id} created!"
     end

--- a/spec/factories/trips.rb
+++ b/spec/factories/trips.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :trip do
     user
     host
+    listing
 
     trip_status 1
     start_date "2017-07-12"


### PR DESCRIPTION
…akefile to reflect those changes. also adds listing to the trips factory

## Status
**READY/IN DEVELOPMENT/HOLD**

## Migrations
YES | NO

## Description
A few sentences describing the overall goals of the pull request's commits.

## Related PRs
List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

```sh
git pull --prune
git checkout <feature_branch>
bundle; script/server
```

1. 

## Impacted Areas in Application
List general components of the application that this PR will affect:

* 
